### PR TITLE
[Fix] Provenance repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lichtblick-suite/rosmsg.git"
+    "url": "https://github.com/Lichtblick-Suite/rosmsg"
   },
   "keywords": [
     "ros",


### PR DESCRIPTION
The url on package.json has to match the repo url.